### PR TITLE
mruby-mysqlを使えるようにする

### DIFF
--- a/ngx_mruby/build_config.rb
+++ b/ngx_mruby/build_config.rb
@@ -13,6 +13,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'mattn/mruby-json'
   conf.gem :github => 'mattn/mruby-onig-regexp'
+  conf.gem :github => 'mattn/mruby-mysql'
   conf.gem :github => 'matsumoto-r/mruby-redis'
   # conf.gem :github => 'matsumoto-r/mruby-memcached'
   conf.gem :github => 'matsumoto-r/mruby-sleep'


### PR DESCRIPTION
* What

https://github.com/mattn/mruby-mysql を使えるようにします。

* Why

DBから取得したデータをnginxの設定に反映させるため。

* How

ビルド時に読み込むmodule一覧に `conf.gem :github => 'mattn/mruby-mysql'` を追加します。