### PR TITLE
mysql_configコマンドを使えるようにする

### DIFF
--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -4,7 +4,7 @@ MAINTAINER hsbt@ruby-lang.org
 RUN yum -y install --enablerepo=extras epel-release
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install wget tar openssl-devel
-RUN yum -y install rpm-build rpmdevtools yum-utils mercurial perl-ExtUtils-Embed
+RUN yum -y install rpm-build rpmdevtools yum-utils mercurial perl-ExtUtils-Embed mysql-devel
 
 RUN wget https://s3.amazonaws.com/pkgr-buildpack-ruby/current/centos-6/ruby-2.2.3.tgz
 RUN tar xf ruby-2.2.3.tgz -C /usr/local

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -4,7 +4,7 @@ MAINTAINER hsbt@ruby-lang.org
 RUN yum -y install --enablerepo=extras epel-release
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake openssl-devel wget
-RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which
+RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which mysql-devel
 
 ENV NGINX_VERSION 1.11.2
 

--- a/Dockerfile.centos7.openssl_static
+++ b/Dockerfile.centos7.openssl_static
@@ -4,7 +4,7 @@ MAINTAINER hsbt@ruby-lang.org
 RUN yum -y install --enablerepo=extras epel-release
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install rake wget
-RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which
+RUN yum -y install rpm-build rpmdevtools yum-utils mercurial which mysql-devel
 
 ENV NGINX_VERSION 1.11.2
 

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -3,7 +3,7 @@ MAINTAINER hsbt@ruby-lang.org
 
 RUN apt-get -qq update && apt-get -qq install -y software-properties-common
 RUN add-apt-repository -y ppa:brightbox/ruby-ng
-RUN apt-get -qq update && apt-get -qq install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev
+RUN apt-get -qq update && apt-get -qq install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev libmysqlclient-dev
 RUN ruby-switch --set ruby2.1
 
 RUN wget http://nginx.org/keys/nginx_signing.key

--- a/Dockerfile.ubuntu1504
+++ b/Dockerfile.ubuntu1504
@@ -3,7 +3,7 @@ MAINTAINER hsbt@ruby-lang.org
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:brightbox/ruby-ng
-RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev
+RUN apt-get update && apt-get install -y git build-essential devscripts ruby2.1 rake bison libssl-dev ruby-switch wget libxslt-dev libgd-dev libgeoip-dev libperl-dev libmysqlclient-dev
 RUN ruby-switch --set ruby2.1
 
 RUN wget http://nginx.org/keys/nginx_signing.key

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER hsbt@ruby-lang.org
 
-RUN apt-get -qq update && apt-get -qq install -y git build-essential devscripts ruby rake bison libssl-dev wget libxslt-dev libgd-dev libgeoip-dev libperl-dev
+RUN apt-get -qq update && apt-get -qq install -y git build-essential devscripts ruby rake bison libssl-dev wget libxslt-dev libgd-dev libgeoip-dev libperl-dev libmysqlclient-dev
 
 RUN wget -qO - http://nginx.org/keys/nginx_signing.key | apt-key add -
 RUN echo 'deb http://nginx.org/packages/mainline/ubuntu/ xenial nginx' >> /etc/apt/sources.list


### PR DESCRIPTION
mysql_configコマンドを使えるようにするため、
CentOSでmysql-devel、Ubuntuではlibmysqlclient-devパッケージをインストールします。

mattn/mruby-mysqlのインストール時にmysql_configコマンドが無いと失敗します。
このコマンドは、このPRでインストールするパッケージの中に含まれています。